### PR TITLE
feat: add vertical orientation support to SlideToUnlock

### DIFF
--- a/app/api/app.api
+++ b/app/api/app.api
@@ -1,14 +1,19 @@
 public final class com/revenuecat/slidetounlockdemo/ComposableSingletons$MainActivityKt {
 	public static final field INSTANCE Lcom/revenuecat/slidetounlockdemo/ComposableSingletons$MainActivityKt;
 	public fun <init> ()V
+	public final fun getLambda$-238258827$app_release ()Lkotlin/jvm/functions/Function9;
+	public final fun getLambda$-55614235$app_release ()Lkotlin/jvm/functions/Function8;
 	public final fun getLambda$-794938742$app_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$136809679$app_release ()Lkotlin/jvm/functions/Function7;
-	public final fun getLambda$1441203408$app_release ()Lkotlin/jvm/functions/Function7;
+	public final fun getLambda$1248779494$app_release ()Lkotlin/jvm/functions/Function8;
 	public final fun getLambda$1783585206$app_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/revenuecat/slidetounlockdemo/MainActivity : androidx/activity/ComponentActivity {
 	public static final field $stable I
 	public fun <init> ()V
+}
+
+public final class com/revenuecat/slidetounlockdemo/MainActivityKt {
+	public static final fun StackedVerticalText-FNF3uiM (Ljava/lang/String;Landroidx/compose/ui/Modifier;JLandroidx/compose/runtime/Composer;II)V
 }
 

--- a/slidetounlock/api/android/slidetounlock.api
+++ b/slidetounlock/api/android/slidetounlock.api
@@ -56,6 +56,14 @@ public final class com/revenuecat/purchases/slidetounlock/HintTexts$Companion {
 	public final fun defaultHintTexts ()Lcom/revenuecat/purchases/slidetounlock/HintTexts;
 }
 
+public final class com/revenuecat/purchases/slidetounlock/SlideOrientation : java/lang/Enum {
+	public static final field Horizontal Lcom/revenuecat/purchases/slidetounlock/SlideOrientation;
+	public static final field Vertical Lcom/revenuecat/purchases/slidetounlock/SlideOrientation;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/revenuecat/purchases/slidetounlock/SlideOrientation;
+	public static fun values ()[Lcom/revenuecat/purchases/slidetounlock/SlideOrientation;
+}
+
 public abstract interface class com/revenuecat/purchases/slidetounlock/SlideToUnlockColors {
 	public abstract fun hintColor-XeAY9LY (FLandroidx/compose/runtime/Composer;I)J
 	public abstract fun progressColor-WaAFU9c (Landroidx/compose/runtime/Composer;I)J
@@ -70,14 +78,14 @@ public abstract interface class com/revenuecat/purchases/slidetounlock/SlideToUn
 public final class com/revenuecat/purchases/slidetounlock/SlideToUnlockDefaults {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/revenuecat/purchases/slidetounlock/SlideToUnlockDefaults;
-	public final fun Hint (Lcom/revenuecat/purchases/slidetounlock/HintTexts;ZFLcom/revenuecat/purchases/slidetounlock/SlideToUnlockColors;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
-	public final fun Thumb-8HUqYh0 (ZJLcom/revenuecat/purchases/slidetounlock/SlideToUnlockColors;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public final fun Hint (Lcom/revenuecat/purchases/slidetounlock/HintTexts;ZFLcom/revenuecat/purchases/slidetounlock/SlideToUnlockColors;Landroidx/compose/foundation/layout/PaddingValues;Lcom/revenuecat/purchases/slidetounlock/SlideOrientation;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public final fun Thumb-coD9juw (ZJLcom/revenuecat/purchases/slidetounlock/SlideToUnlockColors;Lcom/revenuecat/purchases/slidetounlock/SlideOrientation;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 	public final fun getPaddings-D9Ej5fM ()F
 	public final fun getThumbSize-D9Ej5fM ()F
 	public final fun getVelocityThreshold-D9Ej5fM ()F
 }
 
 public final class com/revenuecat/purchases/slidetounlock/SlideToUnlockKt {
-	public static final fun SlideToUnlock-lbUUqPM (ZLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Lcom/revenuecat/purchases/slidetounlock/SlideToUnlockColors;Lcom/revenuecat/purchases/slidetounlock/HintTexts;Landroidx/compose/ui/graphics/Shape;JFLandroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function7;Lkotlin/jvm/functions/Function8;Landroidx/compose/runtime/Composer;III)V
+	public static final fun SlideToUnlock-PVngBv4 (ZLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Lcom/revenuecat/purchases/slidetounlock/SlideToUnlockColors;Lcom/revenuecat/purchases/slidetounlock/HintTexts;Landroidx/compose/ui/graphics/Shape;JFLandroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;Lkotlin/jvm/functions/Function1;Lcom/revenuecat/purchases/slidetounlock/SlideOrientation;Lkotlin/jvm/functions/Function8;Lkotlin/jvm/functions/Function9;Landroidx/compose/runtime/Composer;III)V
 }
 

--- a/slidetounlock/api/desktop/slidetounlock.api
+++ b/slidetounlock/api/desktop/slidetounlock.api
@@ -56,6 +56,14 @@ public final class com/revenuecat/purchases/slidetounlock/HintTexts$Companion {
 	public final fun defaultHintTexts ()Lcom/revenuecat/purchases/slidetounlock/HintTexts;
 }
 
+public final class com/revenuecat/purchases/slidetounlock/SlideOrientation : java/lang/Enum {
+	public static final field Horizontal Lcom/revenuecat/purchases/slidetounlock/SlideOrientation;
+	public static final field Vertical Lcom/revenuecat/purchases/slidetounlock/SlideOrientation;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/revenuecat/purchases/slidetounlock/SlideOrientation;
+	public static fun values ()[Lcom/revenuecat/purchases/slidetounlock/SlideOrientation;
+}
+
 public abstract interface class com/revenuecat/purchases/slidetounlock/SlideToUnlockColors {
 	public abstract fun hintColor-XeAY9LY (FLandroidx/compose/runtime/Composer;I)J
 	public abstract fun progressColor-WaAFU9c (Landroidx/compose/runtime/Composer;I)J
@@ -70,14 +78,14 @@ public abstract interface class com/revenuecat/purchases/slidetounlock/SlideToUn
 public final class com/revenuecat/purchases/slidetounlock/SlideToUnlockDefaults {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/revenuecat/purchases/slidetounlock/SlideToUnlockDefaults;
-	public final fun Hint (Lcom/revenuecat/purchases/slidetounlock/HintTexts;ZFLcom/revenuecat/purchases/slidetounlock/SlideToUnlockColors;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
-	public final fun Thumb-8HUqYh0 (ZJLcom/revenuecat/purchases/slidetounlock/SlideToUnlockColors;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public final fun Hint (Lcom/revenuecat/purchases/slidetounlock/HintTexts;ZFLcom/revenuecat/purchases/slidetounlock/SlideToUnlockColors;Landroidx/compose/foundation/layout/PaddingValues;Lcom/revenuecat/purchases/slidetounlock/SlideOrientation;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public final fun Thumb-coD9juw (ZJLcom/revenuecat/purchases/slidetounlock/SlideToUnlockColors;Lcom/revenuecat/purchases/slidetounlock/SlideOrientation;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 	public final fun getPaddings-D9Ej5fM ()F
 	public final fun getThumbSize-D9Ej5fM ()F
 	public final fun getVelocityThreshold-D9Ej5fM ()F
 }
 
 public final class com/revenuecat/purchases/slidetounlock/SlideToUnlockKt {
-	public static final fun SlideToUnlock-lbUUqPM (ZLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Lcom/revenuecat/purchases/slidetounlock/SlideToUnlockColors;Lcom/revenuecat/purchases/slidetounlock/HintTexts;Landroidx/compose/ui/graphics/Shape;JFLandroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function7;Lkotlin/jvm/functions/Function8;Landroidx/compose/runtime/Composer;III)V
+	public static final fun SlideToUnlock-PVngBv4 (ZLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Lcom/revenuecat/purchases/slidetounlock/SlideToUnlockColors;Lcom/revenuecat/purchases/slidetounlock/HintTexts;Landroidx/compose/ui/graphics/Shape;JFLandroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;Lkotlin/jvm/functions/Function1;Lcom/revenuecat/purchases/slidetounlock/SlideOrientation;Lkotlin/jvm/functions/Function8;Lkotlin/jvm/functions/Function9;Landroidx/compose/runtime/Composer;III)V
 }
 


### PR DESCRIPTION
# 🚀 Add Vertical Orientation to `SlideToUnlock`

### 🎯 Goal  
Enhance `SlideToUnlock` by adding **vertical orientation support**, making it more flexible for different UI layouts.  
Currently, the component only supports horizontal sliding. With this update, developers can also enable **vertical sliding**, which is especially useful for:  
- Compact UIs  
- Bottom sheets  
- Narrow or tall layouts  

---

### 🛠 Implementation Details  
- ✨ Added a new parameter:  
  ```kotlin
  orientation: SlideOrientation = SlideOrientation.Horizontal
  ```  
- 🔄 Implemented proper **gesture detection** for vertical sliding.  
- 📐 Updated **layout measurement & track rendering** to support both orientations.  
- 🖌 Ensured `thumb` and `hint` composables remain aligned and styled correctly in vertical mode.  
- 🔒 Maintains **backward compatibility** with existing horizontal behavior.  

---

### ✍️ Examples  

**Horizontal (default):**  
```kotlin
SlideToUnlock(
    isSlided = isSlided,
    onSlideCompleted = { isSlided = true },
    hintTexts = HintTexts(
        defaultText = "Slide to subscribe",
        slidedText = "Subscribing..."
    )
)
```

**Vertical (new):**  
```kotlin
SlideToUnlock(
    isSlided = isSlided,
    orientation = SlideOrientation.Vertical,
    modifier = Modifier.height(300.dp),
    onSlideCompleted = { isSlided = true },
    hintTexts = HintTexts(
        defaultText = "Swipe down to confirm",
        slidedText = "Confirming..."
    )
)
```

---

### ✅ Prepare for Review  
- [x] Ran `./gradlew spotlessApply` → ✅ Clean formatting  
- [x] Ran `./gradlew apiDump` → ✅ Verified no unintended API changes  
- [x] Tested both orientations in the sample app  

---