### PR TITLE
fix : README.md Contributing link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 </a>
 
 ## Contribution 🧡
-Slide to Unlock is maintained by [RevenueCat](https://www.revenuecat.com?utm_medium=organic&utm_source=github&utm_campaign=advocate). [RevenueCat SDK for Android](https://www.revenuecat.com/docs/getting-started/installation/android?utm_medium=organic&utm_source=github&utm_campaign=advocate) allows you to implement in-app subscriptions and a paywall system on top of Google Play Billing. Also, anyone can contribute to improving code, docs, or something following our [Contributing Guideline](https://github.com/Revenuecat/slide-to-unblock/blob/main/CONTRIBUTING.md).
+Slide to Unlock is maintained by [RevenueCat](https://www.revenuecat.com?utm_medium=organic&utm_source=github&utm_campaign=advocate). [RevenueCat SDK for Android](https://www.revenuecat.com/docs/getting-started/installation/android?utm_medium=organic&utm_source=github&utm_campaign=advocate) allows you to implement in-app subscriptions and a paywall system on top of Google Play Billing. Also, anyone can contribute to improving code, docs, or something following our [Contributing Guideline](https://github.com/RevenueCat/slide-to-unlock/blob/main/CONTRIBUTING.md).
 
 ## Download
 [![Maven Central](https://img.shields.io/maven-central/v/com.revenuecat.purchases/slide-to-unlock.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.revenuecat%22%20AND%20a:%22slidetounlock%22)


### PR DESCRIPTION
### 🎯 Goal

While analyzing the project, I found a typo in the link in the README.md section, so I'd like to correct it.

### 🛠 Implementation Details

This is a modification to README.md, so there are no design changes. Please check the file changes.

### ✍️ Examples


### ✅ Prepare for Review

Ensure your changes are properly formatted and that the public binary API hasn’t changed unintentionally.

```bash
./gradlew spotlessApply
./gradlew apiDump
```

I have successfully run two gradlew commands.

